### PR TITLE
短時間にログが複数出力された時に、まとめて送信する

### DIFF
--- a/src/executor/auto_stop.rs
+++ b/src/executor/auto_stop.rs
@@ -1,5 +1,5 @@
 use std::{
-    sync::mpsc::{channel, RecvTimeoutError, SendError, Sender},
+    sync::mpsc::{channel, RecvTimeoutError::*, SendError, Sender},
     thread, time,
 };
 
@@ -61,14 +61,14 @@ pub fn auto_stop_inspect(stdin: Sender<String>, sec: u64) -> PlayerNotifier {
                     println!("There is/are {} players", players)
                 }
                 Err(err) => match err {
-                    RecvTimeoutError::Timeout => {
+                    Timeout => {
                         if watching && players == 0 {
                             println!("自動終了します……");
                             stdin.send("stop".to_string()).ok();
                             break;
                         }
                     }
-                    RecvTimeoutError::Disconnected => {
+                    Disconnected => {
                         break;
                     }
                 },

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -34,12 +34,9 @@ impl Handler {
         }
     }
 
-    async fn send_message(&self, message: impl AsRef<str>) {
+    async fn send_message(&self, message: impl AsRef<str>) -> Result<Message, SerenityError> {
         let channel = ChannelId(self.config.permission.channel_id);
-
-        if let Err(e) = channel.say(&self.http, message.as_ref()).await {
-            println!("{}", e);
-        }
+        channel.say(&self.http, message.as_ref()).await
     }
 
     async fn is_server_running(&self) -> bool {
@@ -94,7 +91,9 @@ impl EventHandler for Handler {
             "mcend" => send_stop_to_server(self).await,
             // クライアント停止
             "mcsvend" => mcsvend(self).await,
-            _ => self.send_message("存在しないコマンドです。").await,
+            _ => {
+                self.send_message("存在しないコマンドです。").await.ok();
+            }
         }
     }
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -10,6 +10,8 @@ use std::process::exit;
 use std::sync::{mpsc, Arc};
 
 mod command;
+mod log_sender;
+use log_sender::*;
 
 type ArcMutex<T> = Arc<Mutex<T>>;
 
@@ -17,7 +19,7 @@ pub struct Handler {
     config: Config,
     http: Arc<Http>,
     thread_stdin: ArcMutex<Option<mpsc::Sender<String>>>,
-    thread_id: ArcMutex<Option<ChannelId>>,
+    log_thread: ArcMutex<Option<LogSender>>,
 }
 
 impl Handler {
@@ -28,7 +30,7 @@ impl Handler {
             config,
             http,
             thread_stdin: stdin,
-            thread_id: Arc::new(Mutex::new(None)),
+            log_thread: Arc::new(Mutex::new(None)),
         }
     }
 

--- a/src/handler/log_sender.rs
+++ b/src/handler/log_sender.rs
@@ -57,6 +57,10 @@ impl LogSender {
                         {
                             break;
                         };
+
+                        // reset buffer
+                        buf.clear();
+                        str_length = 0;
                     }
                 }
             });

--- a/src/handler/log_sender.rs
+++ b/src/handler/log_sender.rs
@@ -6,7 +6,7 @@ use serenity::model::prelude::ChannelId;
 use std::sync::mpsc::{sync_channel, RecvTimeoutError::*, SyncSender};
 use std::time::Duration;
 
-const MESSAGE_INTERVAL: u64 = 1;
+const MESSAGE_INTERVAL: Duration = Duration::from_millis(800);
 const MESSAGE_NUMBER_THRESHOLD: usize = 5;
 
 pub struct LogSender {
@@ -29,7 +29,7 @@ impl LogSender {
                 loop {
                     let mut send_flag = false;
 
-                    match rx.recv_timeout(Duration::from_secs(MESSAGE_INTERVAL)) {
+                    match rx.recv_timeout(MESSAGE_INTERVAL) {
                         Ok(v) => {
                             buf.push(v);
 

--- a/src/handler/log_sender.rs
+++ b/src/handler/log_sender.rs
@@ -1,0 +1,78 @@
+use std::sync::Arc;
+use std::thread;
+
+use serenity::http::Http;
+use serenity::model::prelude::ChannelId;
+use std::sync::mpsc::{sync_channel, RecvTimeoutError::*, SyncSender};
+use std::time::Duration;
+
+const MESSAGE_INTERVAL: u64 = 1;
+const LENGTH_THRESHOLD: usize = 5;
+pub struct LogSender {
+    pub channel_id: ChannelId,
+    sender: SyncSender<String>,
+}
+
+impl LogSender {
+    pub fn new(channel_id: ChannelId, http: Arc<Http>) -> LogSender {
+        let (sender, rx) = sync_channel(LENGTH_THRESHOLD);
+
+        thread::spawn(move || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+
+            let mut buf: Vec<String> = Vec::new();
+
+            loop {
+                match rx.recv_timeout(Duration::from_secs(MESSAGE_INTERVAL)) {
+                    Ok(v) => {
+                        buf.push(v);
+
+                        if buf.len() >= LENGTH_THRESHOLD {
+                            rt.block_on(async {
+                                LogSender::internal_say(&mut buf, &http, channel_id)
+                                    .await
+                                    .ok();
+                            });
+                        }
+                    }
+                    Err(err) => match err {
+                        Timeout => {
+                            if !buf.is_empty() {
+                                rt.block_on(async {
+                                    LogSender::internal_say(&mut buf, &http, channel_id)
+                                        .await
+                                        .ok();
+                                })
+                            }
+                        }
+                        Disconnected => break,
+                    },
+                };
+            }
+        });
+
+        LogSender { sender, channel_id }
+    }
+
+    /// Send a message to the buffer.
+    ///
+    /// If the number of messages reach `LENGTH_THRESHOLD` or
+    /// no message sent within `MESSAGE_INTERVAL`, send the discord thread the messages.
+    pub fn say(&self, message: String) -> Result<(), ()> {
+        self.sender.send(message).or(Err(()) as Result<(), ()>)
+    }
+
+    async fn internal_say(
+        messages: &mut Vec<String>,
+        http: &Http,
+        thread: ChannelId,
+    ) -> Result<serenity::model::prelude::Message, serenity::Error> {
+        let res = thread.say(http, messages.concat()).await;
+        messages.clear();
+
+        res
+    }
+}


### PR DESCRIPTION
- 大量のログ出力によるDiscordへの負荷を軽減するため、900ミリ秒間隔で送信するよう変更