### PR TITLE
Fix bug where arguments were not passed correctly

### DIFF
--- a/src/executor.rs
+++ b/src/executor.rs
@@ -76,17 +76,18 @@ impl ServerBuilder {
 
 /// Minecraftサーバを起動します。
 fn mcserver_new(jar_file: &str, work_dir: &str, memory: &str) -> io::Result<Child> {
-    self::command_new("java")
-        .current_dir(work_dir)
-        .arg(format!("-Xmx{}", memory))
-        .arg(format!("-Xms{}", memory))
-        .arg("-jar")
-        .arg(jar_file)
-        .arg("nogui")
+    let xmx = &format!("-Xmx{}", memory);
+    let xms = &format!("-Xms{}", memory);
+
+    let java_command = ["java", xmx, xms, "-jar", jar_file, "nogui"];
+    let mut cmd = self::command_new(&java_command.join(" "));
+
+    cmd.current_dir(work_dir)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
+        .stderr(Stdio::piped());
+
+    cmd.spawn()
 }
 
 pub fn server_log_sender(

--- a/src/executor/not_windows.rs
+++ b/src/executor/not_windows.rs
@@ -2,6 +2,7 @@ use std::process::Command;
 
 pub fn command_new(program: &str) -> Command {
     let mut cmd = Command::new("sh");
-    cmd.args(["-c", program]);
+    cmd.arg("-c").arg(program);
+
     cmd
 }


### PR DESCRIPTION
This pull request fixes a bug where the arguments were not being passed correctly in the `mcserver_new` function except windows. The issue was resolved by properly formatting the command arguments and updating the `command_new` function to handle the changes.