### PR TITLE
Update branch name in Rust workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,9 @@ name: Rust
 
 on:
   push:
-    branches: ["master"]
+    branches: ["main"]
   pull_request:
-    branches: ["master"]
+    branches: ["main"]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
This pull request updates the branch name in the Rust workflow from `master` to `main`. This change ensures consistency with the default branch name in the repository.